### PR TITLE
backporting early_hints

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -170,6 +170,22 @@ module ActionDispatch
     def headers
       Http::Headers.new(@env)
     end
+    
+    # Early Hints is an HTTP/2 status code that indicates hints to help a client start
+    # making preparations for processing the final response.
+    #
+    # If the env contains +rack.early_hints+ then the server accepts HTTP2 push for Link headers.
+    #
+    # The +send_early_hints+ method accepts an hash of links as follows:
+    #
+    #   send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    #
+    # If you are using +javascript_include_tag+ or +stylesheet_link_tag+ the
+    # Early Hints headers are included by default if supported.
+    def send_early_hints(links)
+      return unless env["rack.early_hints"]
+      env["rack.early_hints"].call(links)
+    end
 
     # Returns a +String+ with the last requested path including their params.
     #

--- a/railties/lib/rails/commands/server.rb
+++ b/railties/lib/rails/commands/server.rb
@@ -114,7 +114,8 @@ module Rails
         daemonize:          false,
         debugger:           false,
         pid:                File.expand_path("tmp/pids/server.pid"),
-        config:             File.expand_path("config.ru")
+        config:             File.expand_path("config.ru"),
+        early_hints:        true
       })
     end
 


### PR DESCRIPTION
Backports this https://github.com/rails/rails/pull/30744/ from Rails 5.2 to 4.2 so we can get early_hints working together with Puma. 